### PR TITLE
thread_priority_less 스레드 우선순위 비교 구현

### DIFF
--- a/threads/thread.c
+++ b/threads/thread.c
@@ -210,6 +210,21 @@ thread_create (const char *name, int priority,
 	return tid;
 }
 
+/**
+ * @brief 두 스레드의 우선순위를 비교하여, 리스트에서 우선순위 높은 스레드가 먼저 오도록 하기 위한 비교 함수
+ * @details 이 함수는 list_insert_ordered() 사용되어 ready_list와 같은 스레드 리스트를 우선순위(priority)가 높은 순서로 정렬하는 데 사용
+ * @param a a 리스트에 들어 있는 첫 번째 요소 (struct list_elem *)
+ * @param b b 리스트에 들어 있는 두 번째 요소 (struct list_elem *)
+ * @param aux 추가 전달 데이터 (사용되지 않음, NULL이 전달됨)
+ * @return 첫 번째 스레드의 우선순위가 더 높으면 true, 두 번째 스레드의 우선순위가 더 높으면 false 
+ */
+static bool
+thread_priority_less (const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
+	struct thread *t_a = list_entry(a, struct thread, elem);
+	struct thread *t_b = list_entry(b, struct thread, elem);
+	return t_a->priority > t_b->priority;
+}
+
 /* Puts the current thread to sleep.  It will not be scheduled
    again until awoken by thread_unblock().
 
@@ -240,7 +255,7 @@ thread_unblock (struct thread *t) {
 
 	old_level = intr_disable ();
 	ASSERT (t->status == THREAD_BLOCKED);
-	list_push_back (&ready_list, &t->elem);
+	list_insert_ordered(&ready_list, &t->elem, thread_priority_less, NULL);
 	t->status = THREAD_READY;
 	intr_set_level (old_level);
 }
@@ -303,7 +318,7 @@ thread_yield (void) {
 
 	old_level = intr_disable ();
 	if (curr != idle_thread)
-		list_push_back (&ready_list, &curr->elem);
+		list_insert_ordered(&ready_list, &curr->elem, thread_priority_less, NULL);
 	do_schedule (THREAD_READY);
 	intr_set_level (old_level);
 }


### PR DESCRIPTION
설명:
thread_priority_less() 함수는 두 스레드의 우선순위(priority)를 비교하는 함수로,
list_insert_ordered()와 함께 사용되어 ready_list와 같은 스레드 큐를 우선순위가 높은 순서로 정렬하기 위해 사용

구현된 기능:
- list_entry() 매크로를 이용해 list_elem 포인터로부터 struct thread 포인터를 추출
- 두 스레드의 priority 값을 비교
- thread_a->priority > thread_b->priority 조건이 참이면 a가 b보다 먼저 실행되어야 하므로 true 반환

list_insert_ordered()에 비교 함수로 전달되어, 준비 큐 삽입 시 정렬이 자동으로 적용

통과한 테스트:
`alarm-priority` : 여러 스레드가 timer_sleep()을 통해 같은 시점에 깨어날 경우, 우선순위(priority)가 높은 스레드가 먼저 실행되는지를 검증하는 테스트
<img width="566" height="517" alt="image" src="https://github.com/user-attachments/assets/dcf7ae03-cf29-4eb0-93e7-e20777253b2e" />

수정된 파일 & 함수:
- thread_priority_less(): 스레드 우선순위 비교 함수 (새로 추가)
- thread_yield(): list_push_back() → list_insert_ordered()로 수정
- thread_unblock(): list_push_back() → list_insert_ordered()로 수정

영향: 
- ready_list가 우선순위에 따라 정렬되므로, 항상 가장 높은 우선순위의 스레드가 먼저 실행됨
- alarm-priority 테스트 등에서 요구하는 선점형 스케줄링 조건 만족
- thread_set_priority()와 연동하여, 우선순위가 변경된 스레드를 즉시 다시 스케줄링 가능하게 구현할 수 있음
- Pintos 스케줄러의 핵심 정책인 우선순위 기반 스케줄링(priority scheduling) 구현의 초석이 됨
-----

참조:
https://www.notion.so/jactio/thread_unblock-thread_yield-cmp_priority-22dc9595474e80ffbb4bf3cda0c5d5df