### PR TITLE
Fix: thread_priority_less 전역 선언 sema_down 수정

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -143,6 +143,10 @@ void thread_sleep(int64_t tick);
 void thread_awake(void);
 //	feat/timer_sleep
 
+// $feat/thread_priority_less
+bool thread_priority_less (const struct list_elem *a, const struct list_elem *b, void *aux UNUSED);
+// feat/thread_priority_less
+
 int thread_get_priority (void);
 void thread_set_priority (int);
 

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -66,7 +66,9 @@ sema_down (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	while (sema->value == 0) {
-		list_push_back (&sema->waiters, &thread_current ()->elem);
+		// $feat/thread_priority_less
+		list_insert_ordered(&sema->waiters, &thread_current()->elem, thread_priority_less, NULL);
+		// feat/thread_priority_less
 		thread_block ();
 	}
 	sema->value--;

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -221,7 +221,7 @@ thread_create (const char *name, int priority,
  * @param aux 추가 전달 데이터 (사용되지 않음, NULL이 전달됨)
  * @return 첫 번째 스레드의 우선순위가 더 높으면 true, 두 번째 스레드의 우선순위가 더 높으면 false 
  */
-static bool
+bool
 thread_priority_less (const struct list_elem *a, const struct list_elem *b, void *aux UNUSED) {
 	struct thread *t_a = list_entry(a, struct thread, elem);
 	struct thread *t_b = list_entry(b, struct thread, elem);


### PR DESCRIPTION
작업 설명
1. static 으로 선언 된 thread_priority_less() 함수를 헤더파일에 추가 

2. sema_down 시 list_push_back()으로 FIFO 방식으로 동작 되는 것을
thread_priority_less() 함수로  Priority 우선순위 방식으로 wait list에 추가