### PR TITLE
ADD:write_handler 구현

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -10,7 +10,10 @@
 
 //$ADD/write_handler
 #ifdef USERPROG
-#include "filesys/file.h"
+ /**    @iizxcv
+  *     @brief 쓰레드 구조체에 file-table 추가를 위해 헤더추가
+  *     @see https://www.notion.so/jactio/write_handler-233c9595474e804f998de012a4d9a075?source=copy_link#233c9595474e80b8bcd0e4ab9d1fa96c */
+#include "filesys/file.h" 
 #endif
 //ADD/write_handler
 
@@ -143,7 +146,9 @@ struct thread {
 
 
     /**
+     * @iizxcv
      * @brief write 함수구현을 위해 putbuf사용을 위해 생성.
+     * @see https://www.notion.so/jactio/write_handler-233c9595474e804f998de012a4d9a075?source=copy_link#233c9595474e80b8bcd0e4ab9d1fa96c
      */
     struct file* fdt[64]; //$Add/write_handler
     

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -7,6 +7,13 @@
 
 #include "fixed_point.h"  // $Add/fixed_point_h
 #include "threads/interrupt.h"
+
+//$ADD/write_handler
+#ifdef USERPROG
+#include "filesys/file.h"
+#endif
+//ADD/write_handler
+
 #ifdef VM
 #include "vm/vm.h"
 #endif
@@ -133,6 +140,13 @@ struct thread {
 #ifdef USERPROG
     /* Owned by userprog/process.c. */
     uint64_t *pml4; /* Page map level 4 */
+
+
+    /**
+     * @brief write 함수구현을 위해 putbuf사용을 위해 생성.
+     */
+    struct file* fdt[64]; //$Add/write_handler
+    
 #endif
 #ifdef VM
     /* Table for whole virtual memory owned by thread. */

--- a/include/threads/vaddr.h
+++ b/include/threads/vaddr.h
@@ -56,4 +56,8 @@
         ((uint64_t)(vaddr) - (uint64_t)KERN_BASE); \
     })
 
+#define abs(a) ((a) < 0 ? (-1 * (a)) : (a))
+
+#define pg_diff(a, b) (abs(pg_no((a)) - pg_no((b))))
+
 #endif /* threads/vaddr.h */

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -562,6 +562,7 @@ static void init_thread(struct thread *t, const char *name, int priority) {
      * @brief fd 0,1 은 표준 입출력을 써야하기에 나중에 NULL이면 리턴하는 식으로 하기 위해 정의
      */
     #ifdef USERPROG
+    //ㄹfor 문으로 매크로 수만큼 null초기화
         t->fdt[0] = NULL;
         t->fdt[1] = NULL;
     #endif

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -557,6 +557,16 @@ static void init_thread(struct thread *t, const char *name, int priority) {
     if (thread_mlfqs) {
         t->priority = calaculate_priority(t->recent_cpu, t->nice);
     }
+    //$ADD/write_handler
+    /** 
+     * @brief fd 0,1 은 표준 입출력을 써야하기에 나중에 NULL이면 리턴하는 식으로 하기 위해 정의
+     */
+    #ifdef USERPROG
+        t->fdt[0] = NULL;
+        t->fdt[1] = NULL;
+    #endif
+    //ADD/write_handler
+
 
     t->magic = THREAD_MAGIC;
 

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -147,5 +147,12 @@ static void page_fault(struct intr_frame *f) {
     printf("Page fault at %p: %s error %s page in %s context.\n", fault_addr,
            not_present ? "not present" : "rights violation", write ? "writing" : "reading",
            user ? "user" : "kernel");
-    kill(f);
+
+    // FIXME :  vm할떄는 고칠 것, userprog 할 때 MMU 활용하기 위해 임시로 만듦
+    if (!user && fault_addr < KERN_BASE) {
+        f->rip = f->R.rax;
+        f->R.rax = -1;
+    } else {
+        kill(f);
+    }
 }

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -11,7 +11,7 @@
 #include "userprog/gdt.h"
 
 void syscall_entry(void);
-void syscall_handler(struct intr_frame *);
+void syscall_handler(struct intr_frame*);
 
 /* System call.
  *
@@ -37,8 +37,48 @@ void syscall_init(void) {
 }
 
 /* The main system call interface */
-void syscall_handler(struct intr_frame *f UNUSED) {
-    // TODO: Your implementation goes here.
-    printf("system call!\n");
-    thread_exit();
+
+void syscall_handler(struct intr_frame* f) {
+    // // TODO: Your implementation goes here.
+    //  enum intr_level old_level = intr_disable();
+    // int syscall_num = f->R.rax;
+
+    // switch (syscall_num) {
+    //     case SYS_WRITE:
+    //         /* code */
+    //         write_handler(f->R.rdi, f->R.rsi, f->R.rdx);
+
+    //         intr_set_level(old_level);
+    //         break;
+
+    //     default:
+    //         //printf("system call!\n");
+    //         printf("\n  undifind syscall : %d \n", syscall_num);
+    //         thread_exit();
+
+    //         intr_set_level(old_level);
+    //         break;
+    // }
+    
 }
+
+//$ADD/write_handler
+static  write_handler(size_t fd, char* buf, int size) {  // write의 목적은 buf를 fd에 쓰기해주는 함수
+   
+    if (is_user_vaddr(buf)) {
+        if (fd == stdin) {
+            printf("you do wrting stdin. haven't writed at the stdin");
+        } else if (fd == stdout) {
+            putbuf(buf, size);
+        } else if (fd > stdout) {
+            acquire_console();
+            struct file* get_file = get_file_from_fd(fd);
+            file_write(get_file, buf, size);
+            release_console();
+        }
+    }
+}
+static struct file* get_file_from_fd(fd) {
+    return thread_current()->fdt[fd];
+}
+//ADD/write_handler

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -71,19 +71,24 @@ void syscall_handler(struct intr_frame* f) {
 */
 static int write_handler(size_t fd, char* buf, int size) {  // write의 목적은 buf를 fd에 쓰기해주는 함수
    
-    if (is_user_vaddr(buf)) {
+    if (is_user_vaddr(buf+size)) {
+        //buf 에서 size 만큼 실제 할당되었는지 유무체크 - 나중에 구현
+        //user_get~~~~으로 page접근  시도 ? page 있으면 정상 실행 : 없으면 -1 return
         if (fd == stdin) {
             printf("you do wrting stdin. haven't writed at the stdin"); 
         } else if (fd == stdout) {
             putbuf(buf, size);                                          
         } else if (fd > stdout) {
-            acquire_console();                                          
+           // 수정필요 acquire_console();                                          
             struct file* get_file = get_file_from_fd(fd);
             file_write(get_file, buf, size);
-            release_console();
+           //수정필요  release_console();
         }
         return size;
     }
+
+    return -1;
+
 }
 /**
  * @iizxcv

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -73,11 +73,11 @@ static int write_handler(size_t fd, char* buf, int size) {  // write의 목적�
    
     if (is_user_vaddr(buf)) {
         if (fd == stdin) {
-            printf("you do wrting stdin. haven't writed at the stdin"); //fd값이 stdin 이면 경고문 출력과 함께, 종료
+            printf("you do wrting stdin. haven't writed at the stdin"); 
         } else if (fd == stdout) {
-            putbuf(buf, size);
+            putbuf(buf, size);                                          
         } else if (fd > stdout) {
-            acquire_console();
+            acquire_console();                                          
             struct file* get_file = get_file_from_fd(fd);
             file_write(get_file, buf, size);
             release_console();

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -63,11 +63,17 @@ void syscall_handler(struct intr_frame* f) {
 }
 
 //$ADD/write_handler
-static  write_handler(size_t fd, char* buf, int size) {  // write의 목적은 buf를 fd에 쓰기해주는 함수
+/**
+ * @iizxcv
+ * @brief 쓰기 함수 구현. fd를 받아와서 buf에 있는 값을 size 만큼 쓰는 함수임.
+ * @see https://www.notion.so/jactio/write_handler-233c9595474e804f998de012a4d9a075?source=copy_link#233c9595474e80b8bcd0e4ab9d1fa96c
+
+*/
+static int write_handler(size_t fd, char* buf, int size) {  // write의 목적은 buf를 fd에 쓰기해주는 함수
    
     if (is_user_vaddr(buf)) {
         if (fd == stdin) {
-            printf("you do wrting stdin. haven't writed at the stdin");
+            printf("you do wrting stdin. haven't writed at the stdin"); //fd값이 stdin 이면 경고문 출력과 함께, 종료
         } else if (fd == stdout) {
             putbuf(buf, size);
         } else if (fd > stdout) {
@@ -76,8 +82,14 @@ static  write_handler(size_t fd, char* buf, int size) {  // write의 목적은 b
             file_write(get_file, buf, size);
             release_console();
         }
+        return size;
     }
 }
+/**
+ * @iizxcv
+ * @brief fd-no로 현재 쓰레드에 매핑된 file-table에서 file 주소 가져오기
+ * @see https://www.notion.so/jactio/write_handler-233c9595474e804f998de012a4d9a075?source=copy_link#233c9595474e80b8bcd0e4ab9d1fa96c
+*/
 static struct file* get_file_from_fd(fd) {
     return thread_current()->fdt[fd];
 }

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -163,11 +163,11 @@ static int write_handler(size_t fd, char* buf,
                          int size) {  // write의 목적은 buf를 fd에 쓰기해주는 함수
 
     if (is_user_accesable(buf, size, false)) {
-        if (fd == stdin) {
+        if (fd == 0) {
             printf("you do wrting stdin. haven't writed at the stdin");
-        } else if (fd == stdout) {
+        } else if (fd == 1) {
             putbuf(buf, size);
-        } else if (fd > stdout) {
+        } else if (fd > 2) {
             // FIXME: 락이랑 접근해서 작성하는거 구현할 것
             // 수정필요 acquire_console();
             struct file* get_file = get_file_from_fd(fd);

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -12,6 +12,9 @@
 
 void syscall_entry(void);
 void syscall_handler(struct intr_frame*);
+static bool is_user_accesable(void* start, size_t size, bool write);
+static int64_t get_user(const uint8_t* uaddr);
+static bool put_user(uint8_t* udst, uint8_t byte);
 
 /* System call.
  *
@@ -59,43 +62,131 @@ void syscall_handler(struct intr_frame* f) {
     //         intr_set_level(old_level);
     //         break;
     // }
-    
 }
 
-//$ADD/write_handler
-/**
- * @iizxcv
- * @brief 쓰기 함수 구현. fd를 받아와서 buf에 있는 값을 size 만큼 쓰는 함수임.
- * @see https://www.notion.so/jactio/write_handler-233c9595474e804f998de012a4d9a075?source=copy_link#233c9595474e80b8bcd0e4ab9d1fa96c
+/* Reads a byte at user virtual address UADDR.
+ * UADDR must be below KERN_BASE.
+ * Returns the byte value if successful, -1 if a segfault
+ * occurred. */
+static int64_t get_user(const uint8_t* uaddr) {
+    int64_t result;
+    __asm __volatile(
+        "movabsq $done_get, %0\n"  // done_get 레이블의 주소를 result에 저장
+        "movzbq %1, %0\n"  // *uaddr에서 1바이트를 읽어 %0 (result)에 저장. 세그폴트 발생 시 이 부분
+                           // 건너뜀.
+        "done_get:\n"  // (페이지 폴트 핸들러가 result를 -1로 설정하고 여기에 점프하도록 수정되어야
+                       // 함)
+        : "=&a"(result)
+        : "m"(*uaddr));
+    return result;
+}
 
-*/
-static int write_handler(size_t fd, char* buf, int size) {  // write의 목적은 buf를 fd에 쓰기해주는 함수
-   
-    if (is_user_vaddr(buf+size)) {
-        //buf 에서 size 만큼 실제 할당되었는지 유무체크 - 나중에 구현
-        //user_get~~~~으로 page접근  시도 ? page 있으면 정상 실행 : 없으면 -1 return
+/* Writes BYTE to user address UDST.
+ * UDST must be below KERN_BASE.
+ * Returns true if successful, false if a segfault occurred. */
+static bool put_user(uint8_t* udst, uint8_t byte) {
+    int64_t error_code;
+    __asm __volatile(
+        "movabsq $done_put, %0\n"  // done_put 레이블의 주소를 error_code에 저장
+        "movb %b2, %1\n"  // byte를 *udst에 쓴다. 세그폴트 발생 시 이 부분 건너뜀.
+        "done_put:\n"  // (페이지 폴트 핸들러가 error_code를 -1로 설정하고 여기에 점프하도록
+                       // 수정되어야 함)
+        : "=&a"(error_code), "=m"(*udst)
+        : "q"(byte));
+    return error_code != -1;
+}
+
+/**
+ * @brief 사용자 메모리 영역이 접근 가능한지 검사합니다.
+ *
+ * @branch ADD/write_handler
+ * @see
+ * https://www.notion.so/jactio/access_control-235c9595474e8083ba94d4bc3d1ce7e3?source=copy_link
+ * @param start 검사 시작 주소(포인터)
+ * @param size 검사할 바이트 크기
+ * @param write 쓰기 접근 권한도 확인할지 여부 (true일 경우 put_user로 쓰기 검증)
+ * @return 접근 가능하면 true, 그렇지 않으면 false
+ *
+ * start 주소부터 size 바이트 범위 내 각 페이지마다 get_user를 통해 읽기 접근을 확인하고,
+ * write가 true일 경우 put_user를 통해 쓰기 접근도 검증합니다.
+ * 또한, 검사 범위가 커널 영역(KERN_BASE)이상일 경우 즉시 false를 반환합니다.
+ * get_user 및 put_user는 페이지 폴트 발생 시 -1을 반환하도록 구현되어 있습니다.
+ */
+static bool is_user_accesable(void* start, size_t size, bool write) {
+    uintptr_t end = (uintptr_t)start + size, ptr = start;
+    size_t n = pg_diff(start, end);
+    uint8_t byte;
+
+    ASSERT((uintptr_t)start <= (uintptr_t)end);
+
+    if (!is_user_vaddr(end)) {
+        return false;
+    }
+
+    for (int i = 0; i < n + 1; i++) {
+        if ((byte = get_user((uint8_t*)ptr)) == (int64_t)-1) {
+            return false;
+        }
+        if (write) {
+            if (put_user(ptr, byte) == (int64_t)-1) {
+                return false;
+            }
+        }
+        ptr += PGSIZE;
+        if (ptr > end) {
+            ptr = end;
+        }
+    }
+    return true;
+}
+
+/**
+ * @brief 사용자 파일 디스크립터에 버퍼 내용을 씁니다.
+ *
+ * @branch ADD/write_handler
+ *
+ * @iizxcv
+ * @jacti
+ * @param fd    파일 디스크립터 (0: stdin, 1: stdout, >1: 파일)
+ * @param buf   쓰기할 데이터가 있는 사용자 버퍼의 시작 주소
+ * @param size  쓰기할 데이터 크기(바이트 단위)
+ * @return 작성한 바이트 수(size) 또는 접근 오류 시 -1
+ * @see
+ * https://www.notion.so/jactio/write_handler-233c9595474e804f998de012a4d9a075?source=copy_link#233c9595474e80b8bcd0e4ab9d1fa96c
+ *
+ * is_user_accesable을 통해 사용자 버퍼 접근을 검증한 후,
+ * fd가 stdin인 경우 경고 메시지를 출력합니다.
+ * fd가 stdout인 경우 putbuf를 이용해 화면에 출력하며,
+ * 그 외(fd > stdout)의 경우 파일 객체를 fd로부터 가져와 file_write를 호출합니다.
+ */
+static int write_handler(size_t fd, char* buf,
+                         int size) {  // write의 목적은 buf를 fd에 쓰기해주는 함수
+
+    if (is_user_accesable(buf, size, false)) {
         if (fd == stdin) {
-            printf("you do wrting stdin. haven't writed at the stdin"); 
+            printf("you do wrting stdin. haven't writed at the stdin");
         } else if (fd == stdout) {
-            putbuf(buf, size);                                          
+            putbuf(buf, size);
         } else if (fd > stdout) {
-           // 수정필요 acquire_console();                                          
+            // FIXME: 락이랑 접근해서 작성하는거 구현할 것
+            // 수정필요 acquire_console();
             struct file* get_file = get_file_from_fd(fd);
             file_write(get_file, buf, size);
-           //수정필요  release_console();
+            // 수정필요  release_console();
         }
         return size;
     }
 
     return -1;
-
 }
 /**
  * @iizxcv
  * @brief fd-no로 현재 쓰레드에 매핑된 file-table에서 file 주소 가져오기
- * @see https://www.notion.so/jactio/write_handler-233c9595474e804f998de012a4d9a075?source=copy_link#233c9595474e80b8bcd0e4ab9d1fa96c
-*/
+ *
+ * @branch ADD/write_handler
+ * @see
+ * https://www.notion.so/jactio/write_handler-233c9595474e804f998de012a4d9a075?source=copy_link#233c9595474e80b8bcd0e4ab9d1fa96c
+ */
 static struct file* get_file_from_fd(fd) {
     return thread_current()->fdt[fd];
 }
-//ADD/write_handler


### PR DESCRIPTION
## 📌 Pull Request: `write` 시스템 콜 기본 핸들러 구현

### 🔍 요약

이 PR은 사용자 프로그램이 `write()` 시스템 콜을 사용할 수 있도록, Pintos 커널에 기본적인 `write` 핸들러를 추가한 것입니다. 콘솔 출력 (`stdout`)과 파일 디스크립터를 이용한 쓰기를 지원하며, 이를 위해 각 스레드마다 파일 디스크립터 테이블을 추가했습니다.

---

### 🧩 주요 변경 사항

#### 1. `struct thread`에 파일 디스크립터 테이블(fdt) 추가

* `include/threads/thread.h`

  * `#ifdef USERPROG` 안에 `struct file* fdt[64];` 필드 추가
  * 사용자 프로그램이 열 수 있는 최대 파일 수를 64개로 설정
  * `#include "filesys/file.h"` 헤더 추가

#### 2. `init_thread()` 함수 수정 (`threads/thread.c`)

* 새로 생성되는 스레드의 `fdt[0]`과 `fdt[1]`을 `NULL`로 초기화
  → 추후 `stdin`, `stdout` 설정을 위해 구분해두는 용도

#### 3. `syscall_handler()` 기본 구조 설정 (`userprog/syscall.c`)

* 시스템 콜 번호를 추출하고 `write_handler()`를 호출할 수 있도록 기본 구조 주석 형태로 추가

#### 4. `write_handler()` 함수 구현 (`userprog/syscall.c`)

* 매개변수로 받은 `fd`, `buf`, `size`를 바탕으로 콘솔 출력 또는 파일 쓰기 수행
* `fd == 1` (`stdout`)인 경우 `putbuf()` 호출
* `fd > 1`인 경우 `file_write()`를 통해 파일에 기록 (단, console lock 사용 필요)

#### 5. `get_file_from_fd()` 유틸 함수 구현

* 현재 스레드의 `fdt[]`에서 파일 디스크립터 번호로 파일 포인터를 가져오는 함수

---

### 🔗 참고 링크

* 작성자 개인 정리 문서
  [📄 Notion 문서: write\_handler 정리](https://www.notion.so/jactio/write_handler-233c9595474e804f998de012a4d9a075?source=copy_link)

* 추가 변경사항 작업 문서
* [📄 Notion 문서: access_control 구현](https://www.notion.so/jactio/access_control-235c9595474e8083ba94d4bc3d1ce7e3?source=copy_link)


---
