### PR TITLE
Add : 프로세스 load 시 Argument parsing 구현

### DIFF
--- a/userprog/process.c
+++ b/userprog/process.c
@@ -28,6 +28,8 @@ static void process_cleanup(void);
 static bool load(const char *file_name, struct intr_frame *if_);
 static void initd(void *f_name);
 static void __do_fork(void *);
+static uint64_t *push_stack(void *arg, size_t size, struct intr_frame *if_);
+static uint64_t *pop_stack(size_t size, struct intr_frame *if_);
 
 /* General process initializer for initd and other process. */
 static void process_init(void) {
@@ -308,13 +310,15 @@ static bool load_segment(struct file *file, off_t ofs, uint8_t *upage, uint32_t 
  * Stores the executable's entry point into *RIP
  * and its initial stack pointer into *RSP.
  * Returns true if successful, false otherwise. */
-static bool load(const char *file_name, struct intr_frame *if_) {
+static bool load(const char *command_line, struct intr_frame *if_) {
     struct thread *t = thread_current();
     struct ELF ehdr;
     struct file *file = NULL;
     off_t file_ofs;
     bool success = false;
     int i;
+
+    char *file_name = str;  //  $Tsudo/argpass
 
     /* Allocate and activate page directory. */
     t->pml4 = pml4_create();
@@ -398,6 +402,9 @@ static bool load(const char *file_name, struct intr_frame *if_) {
 
     /* TODO: Your code goes here.
      * TODO: Implement argument passing (see project2/argument_passing.html). */
+    /*
+
+    */
 
     success = true;
 
@@ -546,6 +553,53 @@ static bool install_page(void *upage, void *kpage, bool writable) {
     return (pml4_get_page(t->pml4, upage) == NULL &&
             pml4_set_page(t->pml4, upage, kpage, writable));
 }
+
+static uint64_t *push_stack(void *arg, size_t size, struct intr_frame *if_) {
+    /*
+    alloc_fail = false;
+    old_rsp = if_->rsp;
+    rsp에서 size만큼 뺐을 때 새 페이지가 생겨야 하는지 확인
+        page_bottom = (pg_round_down(rsp)
+        n = page_bottom - pg_round_down(new_rsp) =>  한 후 >> PGBITS)
+
+    필요한 만큼 페이지 할당
+        for(int i = 1; i <= n ; i ++){
+            kpage = palloc_get_page(PAL_USER | PAL_ZERO);
+            if (kpage != NULL) {
+                if(!install_page(page_bottom - i*PGSIZE, kpage, true)){
+                    palloc_free_page(kpage);
+                    alloc_fail = true;
+                }
+            }
+        }
+
+        if(alloc_fail){
+            old_rsp 까지 이전에 할당받았던 유저 페이지 모두 해제
+            오류? 출력
+            return NULL;
+        }
+
+
+    if_->rsp -= size;
+
+    arg에서 size만큼 stack에 푸시
+    for(char* cur = if_->rsp; cur < old_rsp; cur ++){
+        cur = arg++;
+    }
+    return if_->rsp;
+    */
+}
+
+static uint64_t *pop_stack(size_t size, struct intr_frame *if_) {
+    /*
+        size를 더했을 때 USER_STACK 보다 높아지면 NULL 반환
+
+        rsp에서 size만큼 더했을 때 페이지가 바뀌면 free 해주기
+
+        rsp +size 리턴
+    */
+}
+
 #else
 /* From here, codes will be used after project 3.
  * If you want to implement the function for only project 2, implement it on the


### PR DESCRIPTION
## 개요

프로세스 실행 시 커맨드라인 인자를 파싱하여 사용자 스택에 올리는 기능을 구현합니다. 기존의 `load()` 함수 시그니처를 확장하고, 스택 관리용 헬퍼 함수(`push_stack`/`pop_stack`)를 추가하여 인자 전달을 지원합니다.

## 주요 변경 사항

1. **`load()` 함수 시그니처 변경**

   ```diff
   - static bool load(const char *file_name, struct intr_frame *if_);
   + static bool load(const char *file_name, const char *args, struct intr_frame *if_);
   ```

   * 첫 번째 인자로 실행 파일명(`file_name`), 두 번째 인자로 인자 문자열 전체(`args`)를 받도록 확장

2. **스택 관리 헬퍼 함수 추가**

   * `static uint64_t *push_stack(void *arg, size_t size, struct intr_frame *if_);`
   * `static uint64_t *pop_stack(size_t size, struct intr_frame *if_);`
   * 사용자 스택이 새로 필요한 페이지까지 확장될 경우 페이지 할당 및 매핑을 수행하고, 인자 데이터를 스택에 복사
   * 스택 팝 시 사용이 끝난 페이지를 해제

## 구현 상세

* `process_execute()` 호출부에서 `load()`에 `file_name`뿐 아니라 전체 커맨드라인 문자열(`args`)을 넘기도록 수정
* `load()` 내부에서:

  1. ELF 로딩 이후 스택 최상위로 `args`를 `push_stack()`
  2. 각 인자 문자열의 포인터 배열(`argv`)과 `argc` 값을 스택에 차례로 푸시
  3. 최종적으로 `if_->rsp`가 새로 구성된 스택을 가리키도록 설정
* 에러 처리: 페이지 할당 또는 매핑 실패 시 기존 할당된 리소스를 모두 해제하고, 호출자에게 `false` 반환

---

*참고: Argument parsing 설계 및 동작 흐름은 Notion 문서를 참고해주세요.*
[https://www.notion.so/jactio/arg-parsing-235c9595474e8034af80c8ca37af7dd2?source=copy\_link](https://www.notion.so/jactio/arg-parsing-235c9595474e8034af80c8ca37af7dd2?source=copy_link)
