### PR TITLE
Fix: userprog 테스트 패닉(sema_up) 및 스택 처리 로직 수정

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -10,12 +10,14 @@
 
 //$ADD/write_handler
 #ifdef USERPROG
- /**    @iizxcv
-  *     @brief 쓰레드 구조체에 file-table 추가를 위해 헤더추가
-  *     @see https://www.notion.so/jactio/write_handler-233c9595474e804f998de012a4d9a075?source=copy_link#233c9595474e80b8bcd0e4ab9d1fa96c */
-#include "filesys/file.h" 
+/**    @iizxcv
+ *     @brief 쓰레드 구조체에 file-table 추가를 위해 헤더추가
+ *     @see
+ * https://www.notion.so/jactio/write_handler-233c9595474e804f998de012a4d9a075?source=copy_link#233c9595474e80b8bcd0e4ab9d1fa96c
+ */
+#include "filesys/file.h"
 #endif
-//ADD/write_handler
+// ADD/write_handler
 
 #ifdef VM
 #include "vm/vm.h"
@@ -144,14 +146,14 @@ struct thread {
     /* Owned by userprog/process.c. */
     uint64_t *pml4; /* Page map level 4 */
 
-
     /**
      * @iizxcv
      * @brief write 함수구현을 위해 putbuf사용을 위해 생성.
-     * @see https://www.notion.so/jactio/write_handler-233c9595474e804f998de012a4d9a075?source=copy_link#233c9595474e80b8bcd0e4ab9d1fa96c
+     * @see
+     * https://www.notion.so/jactio/write_handler-233c9595474e804f998de012a4d9a075?source=copy_link#233c9595474e80b8bcd0e4ab9d1fa96c
      */
-    struct file* fdt[64]; //$Add/write_handler
-    
+    struct file *fdt[64];  //$Add/write_handler
+
 #endif
 #ifdef VM
     /* Table for whole virtual memory owned by thread. */
@@ -186,6 +188,8 @@ const char *thread_name(void);
 
 void thread_exit(void) NO_RETURN;
 void thread_yield(void);
+
+void thread_yield_r(void);
 
 //	$feat/timer_sleep
 void thread_sleep(int64_t tick);

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -328,6 +328,16 @@ void thread_yield(void) {
     intr_set_level(old_level);
 }
 
+/**
+ * @brief 스레드 생성 또는 언블록 후, 우선순위가 더 높은 스레드가 있으면 CPU를 양보함
+ *
+ * thread_unblock() 호출 이후, 현재 스레드의 효과적 우선순위가
+ * 준비 큐(peek된 스레드)의 우선순위보다 낮으면 즉시
+ * 컨텍스트 스위치를 트리거하여 높은 우선순위 스레드에게 CPU를 양보합니다.
+ *
+ * @branch fix/kernel-panic-userprog
+ * @see    https://www.notion.so/jactio/userprog-235c9595474e80569688e4832de8291f?source=copy_link
+ */
 void thread_yield_r(void) {
     if (!list_empty(&ready_list) &&
         get_effective_priority(thread_current()) <

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -590,7 +590,7 @@ static bool install_page(void *upage, void *kpage, bool writable) {
  *
  * @branch feat/arg-parse
  * @see https://www.notion.so/jactio/arg-parsing-235c9595474e8034af80c8ca37af7dd2?source=copy_link
- * @param arg 푸시할 데이터가 저장된 버퍼의 포인터입니다.
+ * @param arg 푸시할 데이터가 저장된 버퍼의 포인터입니다. NULL이면 0 값으로 채웁니다.
  * @param size 푸시할 바이트 수이며, 0보다 커야 합니다.
  * @param if_ 스택 포인터(rsp)를 조정할 intr_frame 구조체의 포인터입니다.
  * @return 성공 시 갱신된 스택 포인터(rsp)를 반환하고, 할당 실패 시 NULL을 반환합니다.


### PR DESCRIPTION
**Pull Request: userprog 테스트 패닉(sema\_up) 및 스택 처리 로직 수정**

---

## 🐛 문제

* `userprog` 테스트 중 `sema_up()` 구현으로 인해 스레드 해제 순서가 올바르지 않아 우선순위 높은 스레드가 즉시 실행되지 않음
* 그 결과 `pml4_activate()` 내 `is_kernel_vaddr(pml4 ? pml4 : base_pml4)` 어설션이 실패하며 커널 패닉 발생

## ✨ 주요 변경사항

### 1. `threads/synch.c`

* **우선순위 기반 해제**

  * 대기 리스트에서 단순 FIFO(`list_pop_front`)가 아닌, 가장 높은 우선순위 스레드를 찾아(`list_max`) 해제하도록 수정
* **스케줄러 호출 개선**

  * `thread_yield()` → `thread_yield_r()` 호출로 인터럽트 비활성화 상태에서도 안전하게 양보

```diff
 void sema_up(struct semaphore *sema) {
     …  
-    if (!list_empty(&sema->waiters))
-        thread_unblock(list_entry(list_pop_front(&sema->waiters), struct thread, elem));
+    if (!list_empty(&sema->waiters)) {
+        struct list_elem *max_elem =
+            list_max(&sema->waiters, thread_priority_less, NULL);
+        list_remove(max_elem);
+        thread_unblock(list_entry(max_elem, struct thread, elem));
+    }
     sema->value++;
-    thread_yield();
+    thread_yield_r();
     intr_set_level(old_level);
 }
```

### 2. `include/threads/thread.h`

  * `struct thread` 내부에 `struct file *fdt[64]` 선언으로 각 스레드별 FD 테이블 확장
* **새 스케줄 함수 선언**

  * `void thread_yield_r(void);` 추가

### 3. `threads/thread.c`

* **중복 include 주석 처리** (`#include "../include/threads/thread.h"`)

### 4. `userprog/process.c`

* **동기화 헤더 포함**: `#include "threads/synch.h"` 추가
* **`process_wait` 임시 루프 주석 처리** (무한 루프 배리어로 최적화 방지)
* **인자 파싱 개선**: 빈 문자열(`args=""`)일 때 `strtok_r` 호출 방지

```diff
+#include "threads/synch.h"

 static bool load(const char *file_name, const char *args, …) {
     argv[0] = file_name;
     uint8_t argc = 1;
     char *save_ptr;
+    if (*args != '\0') {
+        argv[argc] = strtok_r(args, " ", &save_ptr);
+        while (argv[argc] != NULL)
+            argv[++argc] = strtok_r(NULL, " ", &save_ptr);
+    }
     …
 }
```

* **`push_stack` / `pop_stack` 함수 개선**

  * 시그니처: `void *arg` → `char *arg` (arg++ 때 한 바이트 씩 추가되도록)
  * 문서화: `arg == NULL`일 때 0으로 채우도록 설명 추가
  * 구현:

    * **`pg_diff`** 매크로 사용으로 페이지 수 계산 단순화
    * **`USER_STACK`** 특수 처리: 스택의 첫 페이지는 할당 또는 해제 하지 않도록 변경
    * **`arg == NULL`** 시 버퍼에 `'\0'` 채우기

```diff
-static uint64_t *push_stack(void *arg, …) {
+static uint64_t *push_stack(char *arg, size_t size, struct intr_frame *if_) {
     ASSERT(size > 0);
     uintptr_t old_rsp = if_->rsp;
     if_->rsp = old_rsp - size;
-    size_t n = ((pg_round_down(old_rsp) - pg_round_down(if_->rsp)) >> PGBITS);
+    size_t n = pg_diff(old_rsp, if_->rsp);
+    if (old_rsp == USER_STACK)
+        n -= 1;

     … 

     for (char *cur = if_->rsp; cur < old_rsp; cur++) {
-        *cur = *((char *)arg); arg++;
+        if (arg) { *cur = *arg++; }
+        else    { *cur = '\0'; }
     }
     return if_->rsp;
 }

@@ -652,6 +667,10 @@ static uint64_t *pop_stack(size_t size, …
     size_t n = ((pg_round_down(if_->rsp) - page_bottom) >> PGBITS);
+    if (if_->rsp == USER_STACK)
+        n -= 1;
     for (int i = 0; i < n; i++) {
         palloc_free_page(page_bottom);
         page_bottom += PGSIZE;
```

---

## ✅ 검증

- `arg-none` 테스트 정상 실행
- process-wait 이 무한루프이기에, 종료되지는 않음
