### PR TITLE
Fix: fork_handler, wait_handler

### DIFF
--- a/userprog/.test_status
+++ b/userprog/.test_status
@@ -1,2 +1,4 @@
 args-multiple FAIL
 args-none FAIL
+halt PASS
+exit FAIL

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -19,9 +19,9 @@ static bool put_user(uint8_t *udst, uint8_t byte);
 /* $feat/syscall_handler */
 static void halt_handler(void);
 static void exit_handler(int status);
-static tid_t fork_handler(struct intr_frame *f);
+static pid_t fork_handler(const char *thread_name);
 static int exec_handler(const char *file);
-static int wait_handler(tid_t pid);
+static int wait_handler(pid_t pid);
 static bool create_handler(const char *file, unsigned initial_size);
 static bool remove_handler(const char *file);
 static int open_handler(const char *file);
@@ -207,13 +207,13 @@ static void halt_handler(void) {
 static void exit_handler(int status) {
     // 현재 쓰레드 종료 + exit status 저장
     struct thread *cur = thread_current();
-    // cur->status = status;
-    // printf("%s: exit(%d)\n", cur->name, status);
+    // cur->exit_status = status; thread에 exit_status 필요한지 확인 
+    printf("%s: exit(%d)\n", cur->name, status);
     thread_exit();
 }
 
 /* 현재 프로세스를 복사하여 새 프로세스 생성 */
-static tid_t fork_handler(struct intr_frame *f) {
+static pid_t fork_handler(const char *thread_name) {
     // 부모의 메모리와 상태를 복사해 자식 생성
     return -1;  // TODO: 구현 필요
 }
@@ -225,7 +225,7 @@ static int exec_handler(const char *file) {
 }
 
 /* 자식 프로세스가 종료될 때까지 대기 */
-static int wait_handler(tid_t pid) {
+static int wait_handler(pid_t pid) {
     return -1;  // TODO: 구현 필요
 }
 


### PR DESCRIPTION
다음은 위 변경 사항에 대한 **풀리퀘스트(PR) 설명 한글 버전**입니다:

---

### 📌 풀 리퀘스트: `fork` / `wait` 시스템 콜의 인자 타입을 `tid_t` → `pid_t`로 변경

#### 📝 요약

이 PR은 `fork()`와 `wait()` 시스템 콜 핸들러에서 사용하던 `tid_t` 타입을 `pid_t`로 변경했습니다. 이는 핀토스의 userprog 레이어에서 **프로세스와 스레드를 구분**하려는 목적이며, 추후 프로세스 관련 기능 구현을 위한 준비 작업입니다.

#### ✅ 주요 변경 사항

* `fork_handler`와 `wait_handler` 함수 시그니처 변경:

  * `tid_t fork_handler(struct intr_frame *f)` → `pid_t fork_handler(const char *thread_name)`
  * `int wait_handler(tid_t pid)` → `int wait_handler(pid_t pid)`
* 위 함수 선언부와 구현부 수정
* `exit_handler()`에서 `exit_status` 저장은 아직 구현되지 않았지만, 테스트 통과를 위한 `printf()`는 삽입

#### 📌 변경 이유

* 핀토스에서는 내부적으로 프로세스와 스레드를 동일한 `struct thread`로 다루지만, 시스템 콜 인터페이스에서는 **프로세스 단위(`pid_t`)로 구분**하는 것이 논리적으로 더 명확합니다.
* `fork`와 `wait`는 사용자 입장에서 프로세스를 다루는 시스템 콜이기 때문에 `tid_t`보다는 `pid_t`가 적절합니다.
* 추후 자식 프로세스의 상태 추적, 종료 상태 전달, 파일 디스크립터 상속 등 기능을 구현할 때 `pid_t`로 구분하는 것이 더 유리합니다.

---
