### PR TITLE
Fix : thread name & add exit semaphore

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -165,6 +165,7 @@ struct thread {
     struct list_elem sibling_elem;
     struct semaphore wait_sema;
     struct semaphore fork_sema;
+    struct semaphore exit_sema;
     int exit_status;
     // feat/process-wait
 

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -608,6 +608,7 @@ static void init_thread(struct thread *t, const char *name, int priority) {
     t->sibling_elem.next = NULL;
     sema_init(&t->wait_sema, 0);
     sema_init(&t->fork_sema, 0);
+    sema_init(&t->exit_sema, 0);
     t->exit_status = -1;
     // feat/process-wait
 

--- a/userprog/.test_status
+++ b/userprog/.test_status
@@ -2,10 +2,10 @@ exec-bad-ptr PASS
 sm-full PASS
 rox-simple FAIL
 fork-multiple PASS
-args-dbl-space FAIL
+args-dbl-space PASS
 read-bad-fd PASS
 priority-donate-multiple PASS
-args-multiple FAIL
+args-multiple PASS
 lg-seq-random PASS
 syn-write FAIL
 syn-remove PASS
@@ -15,8 +15,8 @@ create-normal PASS
 priority-donate-lower PASS
 bad-write FAIL
 open-twice PASS
-exec-arg PASS
 exec-missing PASS
+exec-arg PASS
 read-bad-ptr PASS
 dup2-complex FAIL
 create-long PASS
@@ -25,8 +25,8 @@ fork-close PASS
 alarm-simultaneous PASS
 fork-boundary PASS
 priority-donate-chain PASS
-create-bound PASS
 rox-multichild FAIL
+create-bound PASS
 lg-random PASS
 priority-condvar PASS
 priority-donate-nest PASS
@@ -39,7 +39,7 @@ open-null PASS
 sm-seq-random PASS
 bad-write2 FAIL
 sm-seq-block PASS
-multi-recurse FAIL
+multi-recurse PASS
 alarm-priority PASS
 close-twice PASS
 args-none PASS
@@ -49,8 +49,8 @@ priority-fifo PASS
 wait-bad-pid PASS
 lg-create PASS
 exec-read PASS
-priority-sema PASS
 read-boundary PASS
+priority-sema PASS
 wait-twice PASS
 exec-boundary PASS
 close-normal PASS
@@ -80,7 +80,7 @@ priority-donate-sema PASS
 lg-seq-block PASS
 wait-simple PASS
 exec-once PASS
-args-many FAIL
+args-many PASS
 fork-read PASS
 write-zero PASS
 alarm-multiple PASS
@@ -90,7 +90,7 @@ bad-jump FAIL
 bad-jump2 FAIL
 open-missing PASS
 create-empty PASS
-args-single FAIL
+args-single PASS
 write-stdin PASS
 read-zero PASS
 bad-read2 FAIL


### PR DESCRIPTION
## 추가 변경사항

### 1. 스레드 구조체 수정
- `include/threads/thread.h`에 `exit_sema` 세마포어 추가  
  부모–자식 동기화용 `wait_sema`와 별도로, 부모가 자식 종료를 모두 처리한 뒤 자식이 안전하게 정리되도록 분리

---

### 2. 프로세스 대기/종료 로직 개선
- **`process_wait`**  
  - 기존에 부모가 자기 자신의 `wait_sema`만 사용하던 동기화를  
    자식(`t`)의 `wait_sema` 대기로 전환  
  - 자식 종료 상태 취득 후 `exit_sema`로 부모에게 완료 신호 전달  
- **`process_exit`**  
  - 종료 시 `sema_up(&cur->wait_sema)`로 부모를 깨우고,  
    `sema_down(&cur->exit_sema)`로 부모가 상태를 읽을 때까지 대기  
  - 이중 세마포어 사용으로 부모‧자식 간 안전한 종료 통신 보장

---

### 3. 스레드 이름 변경 시점 조정
- **`thread.c`**  
  `exec` 직후 불필요하게 호출되던  `strlcpy(thread_current()->name, …);` 제거

* **`userprog/process.c`**의 `load` 함수
  로딩 시점에서 스레드 이름을 변경하던 것을 로딩 앞 thread 생성시점으로 수정