### PR TITLE
Fix/lg full

### DIFF
--- a/include/threads/vaddr.h
+++ b/include/threads/vaddr.h
@@ -58,6 +58,6 @@
 
 #define abs(a) ((a) < 0 ? (-1 * (a)) : (a))
 
-#define pg_diff(a, b) (abs(pg_no((a)) - pg_no((b))))
+#define pg_diff(a, b) ((size_t)(abs((__int128_t)(pg_no((a))) - (__int128_t)(pg_no((b))))))
 
 #endif /* threads/vaddr.h */

--- a/include/userprog/check_perm.h
+++ b/include/userprog/check_perm.h
@@ -1,0 +1,19 @@
+#ifndef USERPROG_CHECK_PERM_H
+#define USERPROG_CHECK_PERM_H
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* check_perm.h의 내용은 이곳에 작성하세요 */
+enum pointer_check_flags {
+    P_KERNEL = 0b0, /* kernel addr */
+    P_USER = 0b1,   /* user addr */
+    P_WRITE = 0b10, /* need write permission */
+    IS_STR = 0b100  /* pointer is char* */
+};
+
+int64_t get_user(const uint8_t *uaddr);
+bool put_user(uint8_t *udst, uint8_t byte);
+bool is_user_accesable(void *start, size_t size, enum pointer_check_flags flag);
+
+#endif /* USERPROG_CHECK_PERM_H */

--- a/include/userprog/file_abstract.h
+++ b/include/userprog/file_abstract.h
@@ -1,5 +1,5 @@
-#ifndef __USERPROG_FILE_ABSTRACT_H
-#define __USERPROG_FILE_ABSTRACT_H
+#ifndef USERPROG_FILE_ABSTRACT_H
+#define USERPROG_FILE_ABSTRACT_H
 
 #include "filesys/file.h"
 
@@ -113,6 +113,6 @@ int close_file(struct File* file);
  */
 struct File* duplicate_file(struct File* file);
 
-#endif /* __USERPROG_FILE_ABSTRACT_H */
-
 bool is_file_writable(struct File* file);
+
+#endif /* USERPROG_FILE_ABSTRACT_H */

--- a/userprog/.test_status
+++ b/userprog/.test_status
@@ -70,7 +70,7 @@ fork-once PASS
 priority-change PASS
 write-boundary PASS
 wait-killed PASS
-lg-full FAIL
+lg-full PASS
 close-bad-fd PASS
 alarm-negative PASS
 multi-child-fd PASS

--- a/userprog/check_perm.c
+++ b/userprog/check_perm.c
@@ -1,0 +1,86 @@
+#include "userprog/check_perm.h"
+
+#include "threads/vaddr.h"
+
+/* Reads a byte at user virtual address UADDR.
+ * UADDR must be below KERN_BASE.
+ * Returns the byte value if successful, -1 if a segfault
+ * occurred. */
+int64_t get_user(const uint8_t *uaddr) {
+    int64_t result;
+    __asm __volatile(
+        "movabsq $done_get, %0\n"  // done_get 레이블의 주소를 result에 저장
+        "movzbq %1, %0\n"  // *uaddr에서 1바이트를 읽어 %0 (result)에 저장. 세그폴트 발생 시 이 부분
+                           // 건너뜀.
+        "done_get:\n"  // (페이지 폴트 핸들러가 result를 -1로 설정하고 여기에 점프하도록 수정되어야
+                       // 함)
+        : "=&a"(result)
+        : "m"(*uaddr), "c"(uaddr));
+    return result;
+}
+
+/* Writes BYTE to user address UDST.
+ * UDST must be below KERN_BASE.
+ * Returns true if successful, false if a segfault occurred. */
+bool put_user(uint8_t *udst, uint8_t byte) {
+    int64_t error_code;
+    __asm __volatile(
+        "movabsq $done_put, %0\n"  // done_put 레이블의 주소를 error_code에 저장
+        "movb %b2, %1\n"  // byte를 *udst에 쓴다. 세그폴트 발생 시 이 부분 건너뜀.
+        "done_put:\n"  // (페이지 폴트 핸들러가 error_code를 -1로 설정하고 여기에 점프하도록
+                       // 수정되어야 함)
+        : "=&a"(error_code), "=m"(*udst)
+        : "q"(byte), "c"(udst));
+    return error_code != -1;
+}
+
+/**
+ * @brief 사용자 메모리 영역이 접근 가능한지 검사합니다.
+ *
+ * @branch ADD/write_handler
+ * @see
+ * https://www.notion.so/jactio/access_control-235c9595474e8083ba94d4bc3d1ce7e3?source=copy_link
+ * @param start 검사 시작 주소(포인터)
+ * @param size 검사할 바이트 크기
+ * @param write 쓰기 접근 권한도 확인할지 여부 (true일 경우 put_user로 쓰기 검증)
+ * @return 접근 가능하면 true, 그렇지 않으면 false
+ *
+ * start 주소부터 size 바이트 범위 내 각 페이지마다 get_user를 통해 읽기 접근을 확인하고,
+ * write가 true일 경우 put_user를 통해 쓰기 접근도 검증합니다.
+ * 또한, 검사 범위가 커널 영역(KERN_BASE)이상일 경우 즉시 false를 반환합니다.
+ * get_user 및 put_user는 페이지 폴트 발생 시 -1을 반환하도록 구현되어 있습니다.
+ */
+bool is_user_accesable(void *start, size_t size, enum pointer_check_flags flag) {
+    if (flag & IS_STR) {
+        if (get_user((uint8_t *)start) == (int64_t)-1) {
+            return false;
+        }
+        size = strlen(start) + 1;
+    }
+
+    uintptr_t end = (uintptr_t)start + size, ptr = start;
+    size_t n = pg_diff(start, end);
+    int64_t byte;
+
+    ASSERT((uintptr_t)start <= (uintptr_t)end);
+
+    if (start == NULL || ((flag & P_USER) && !is_user_vaddr(end))) {
+        return false;
+    }
+
+    for (int i = 0; i < n + 1; i++) {
+        if ((byte = get_user((uint8_t *)ptr)) == (int64_t)-1) {
+            return false;
+        }
+        if (flag & P_WRITE) {
+            if (put_user(ptr, (uint8_t)byte) == (int64_t)-1) {
+                return false;
+            }
+        }
+        ptr += PGSIZE;
+        if (ptr > end) {
+            ptr = end;
+        }
+    }
+    return true;
+}

--- a/userprog/file_abstract.c
+++ b/userprog/file_abstract.c
@@ -2,6 +2,7 @@
 
 #include "filesys/filesys.h"
 #include "threads/malloc.h"
+#include "userprog/check_perm.h"
 #include "userprog/file_abstract.h"
 
 struct File STDIN_FILE = {.type = STDIN, .file_ptr = NULL};

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -480,11 +480,11 @@ static bool load(const char *file_name, char *args, struct intr_frame *if_) {
 
     /* Open executable file. */
     file_a = open_file(file_name);
-    file = file_a->file_ptr;
-    if (file == NULL) {
+    if (file_a == NULL) {
         printf("load: %s: open failed\n", file_name);
         goto done;
     }
+    file = file_a->file_ptr;
 
     /* Read and verify executable header. */
     if (file_read(file, &ehdr, sizeof ehdr) != sizeof ehdr ||
@@ -583,13 +583,12 @@ static bool load(const char *file_name, char *args, struct intr_frame *if_) {
     if_->R.rdi = argc;
     //  feat/arg-parse
 
-    success = true;
-
-done:
     if (!is_file_writable(file_a)) {
         file_deny_write(file_a->file_ptr);
     }
     set_fd(file_a);
+    success = true;
+done:
     return success;
 }
 

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -12,22 +12,13 @@
 #include "threads/palloc.h"
 #include "threads/thread.h"
 #include "user/syscall.h"
+#include "userprog/check_perm.h"
 #include "userprog/file_abstract.h"
 #include "userprog/gdt.h"
 #include "userprog/process.h"
 
-enum pointer_check_flags {
-    P_KERNEL = 0b0, /* kernel addr */
-    P_USER = 0b1,   /* user addr */
-    P_WRITE = 0b10, /* need write permission */
-    IS_STR = 0b100  /* pointer is char* */
-};
-
 void syscall_entry(void);
 void syscall_handler(struct intr_frame *);
-static bool is_user_accesable(void *start, size_t size, enum pointer_check_flags flag);
-static int64_t get_user(const uint8_t *uaddr);
-static bool put_user(uint8_t *udst, uint8_t byte);
 
 /* $feat/syscall_handler */
 static void halt_handler(void);
@@ -123,88 +114,6 @@ void syscall_handler(struct intr_frame *f) {
             printf("undefined system call number: %d\n", syscall_num);
             thread_exit();
     }
-}
-/* Reads a byte at user virtual address UADDR.
- * UADDR must be below KERN_BASE.
- * Returns the byte value if successful, -1 if a segfault
- * occurred. */
-static int64_t get_user(const uint8_t *uaddr) {
-    int64_t result;
-    __asm __volatile(
-        "movabsq $done_get, %0\n"  // done_get 레이블의 주소를 result에 저장
-        "movzbq %1, %0\n"  // *uaddr에서 1바이트를 읽어 %0 (result)에 저장. 세그폴트 발생 시 이 부분
-                           // 건너뜀.
-        "done_get:\n"  // (페이지 폴트 핸들러가 result를 -1로 설정하고 여기에 점프하도록 수정되어야
-                       // 함)
-        : "=&a"(result)
-        : "m"(*uaddr), "c"(uaddr));
-    return result;
-}
-
-/* Writes BYTE to user address UDST.
- * UDST must be below KERN_BASE.
- * Returns true if successful, false if a segfault occurred. */
-static bool put_user(uint8_t *udst, uint8_t byte) {
-    int64_t error_code;
-    __asm __volatile(
-        "movabsq $done_put, %0\n"  // done_put 레이블의 주소를 error_code에 저장
-        "movb %b2, %1\n"  // byte를 *udst에 쓴다. 세그폴트 발생 시 이 부분 건너뜀.
-        "done_put:\n"  // (페이지 폴트 핸들러가 error_code를 -1로 설정하고 여기에 점프하도록
-                       // 수정되어야 함)
-        : "=&a"(error_code), "=m"(*udst)
-        : "q"(byte), "c"(udst));
-    return error_code != -1;
-}
-
-/**
- * @brief 사용자 메모리 영역이 접근 가능한지 검사합니다.
- *
- * @branch ADD/write_handler
- * @see
- * https://www.notion.so/jactio/access_control-235c9595474e8083ba94d4bc3d1ce7e3?source=copy_link
- * @param start 검사 시작 주소(포인터)
- * @param size 검사할 바이트 크기
- * @param write 쓰기 접근 권한도 확인할지 여부 (true일 경우 put_user로 쓰기 검증)
- * @return 접근 가능하면 true, 그렇지 않으면 false
- *
- * start 주소부터 size 바이트 범위 내 각 페이지마다 get_user를 통해 읽기 접근을 확인하고,
- * write가 true일 경우 put_user를 통해 쓰기 접근도 검증합니다.
- * 또한, 검사 범위가 커널 영역(KERN_BASE)이상일 경우 즉시 false를 반환합니다.
- * get_user 및 put_user는 페이지 폴트 발생 시 -1을 반환하도록 구현되어 있습니다.
- */
-static bool is_user_accesable(void *start, size_t size, enum pointer_check_flags flag) {
-    if (flag & IS_STR) {
-        if (get_user((uint8_t *)start) == (int64_t)-1) {
-            return false;
-        }
-        size = strlen(start) + 1;
-    }
-
-    uintptr_t end = (uintptr_t)start + size, ptr = start;
-    size_t n = pg_diff(start, end);
-    int64_t byte;
-
-    ASSERT((uintptr_t)start <= (uintptr_t)end);
-
-    if (start == NULL || ((flag & P_USER) && !is_user_vaddr(end))) {
-        return false;
-    }
-
-    for (int i = 0; i < n + 1; i++) {
-        if ((byte = get_user((uint8_t *)ptr)) == (int64_t)-1) {
-            return false;
-        }
-        if (flag & P_WRITE) {
-            if (put_user(ptr, (uint8_t)byte) == (int64_t)-1) {
-                return false;
-            }
-        }
-        ptr += PGSIZE;
-        if (ptr > end) {
-            ptr = end;
-        }
-    }
-    return true;
 }
 
 /**

--- a/userprog/targets.mk
+++ b/userprog/targets.mk
@@ -5,3 +5,4 @@ userprog_SRC += userprog/syscall.c	# System call handler.
 userprog_SRC += userprog/gdt.c		# GDT initialization.
 userprog_SRC += userprog/tss.c		# TSS management.
 userprog_SRC += userprog/file_abstract.c	# FILE absraction
+userprog_SRC += userprog/check_perm.c		# check_permission


### PR DESCRIPTION
## 개요
1. 권한 체크 함수(`get_user`, `put_user`, `is_user_accessable`)를 별도 모듈로 분리  
2. `exec` 시 실행 파일이 없을 때 올바르게 처리하도록 수정하여 `exec-missing`, `wait-kill` 테스트 통과  
3. `pg_diff` 매크로 오버플로우 오류 수정하여 `lg-full` 테스트 통과  

---

## 주요 변경 사항

### 1. 권한 체크 함수 분리
- **신규 파일 추가**  
  - `include/userprog/check_perm.h`  
  - `userprog/check_perm.c`  
- **변경 내용**  
  - `get_user`, `put_user`, `is_user_accessable` 함수 선언·구현을 위 두 파일로 이동  
  - `userprog/syscall.c` 등 기존 위치에서 해당 함수 정의 제거  
  - `userprog/targets.mk`에 `userprog/check_perm.c` 추가  

### 2. exec 파일 누락 처리 개선
- **수정 파일**: `userprog/process.c`  
- **변경 전**  
  ```c
  file_a = open_file(file_name);
  file = file_a->file_ptr;
  if (file == NULL) {
      printf("load: %s: open failed\n", file_name);
      goto done;
  }
  ```

- **변경 후**
  ```c
  file_a = open_file(file_name);
  if (file_a == NULL) {
      printf("load: %s: open failed\n", file_name);
      goto done;
  }
  file = file_a->file_ptr;
  ```

- **효과**

  * `open_file()` 실패 시 `file_ptr` 접근을 방지
  * Missing exec 테스트(`exec-missing`, `wait-kill`) 통과

### 3. `pg_diff` 매크로 오버플로우 방지

- **수정 파일**: `include/threads/vaddr.h`
- **변경 전**

  ```c
  #define pg_diff(a, b) (abs(pg_no((a)) - pg_no((b))))
  ```

- **변경 후**

  ```c
  #define pg_diff(a, b) \
    ((size_t)(abs((__int128_t)(pg_no(a)) - (__int128_t)(pg_no(b)))))
  ```

- **효과**

  * 차이가 큰 경우에도 128비트 연산 후 `size_t`로 안전하게 캐스팅
  * `lg-full` 테스트 통과

---

## 테스트 결과

* `exec-missing` ✔
* `wait-kill`  ✔
* `lg-full`   ✔

---

## 영향 및 참고 사항

* 코드 모듈화 강화로 유지보수성 향상
* 잘못된 `exec` 경로 처리로 인한 커널 패닉 방지
* 주소 차이 계산 안정성 확보

---
